### PR TITLE
Add delete link for each bulk discount, aka destroy method

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -13,11 +13,10 @@ class BulkDiscountsController < ApplicationController
   def new
   end
 
-
   def create
     bulk_discount = BulkDiscount.new(bulk_discount_params)
     merchant = Merchant.find(bulk_discount_params[:merchant_id])
-    
+
     if bulk_discount.save
       redirect_to merchant_bulk_discounts_path(merchant),
       notice: "bulk discount successfully created!"
@@ -25,6 +24,13 @@ class BulkDiscountsController < ApplicationController
       redirect_to new_merchant_bulk_discount_path(merchant)
       flash[:alert] = "Error: #{error_message(bulk_discount.errors)}"
     end
+  end
+
+  def destroy
+    merchant = Merchant.find(bulk_discount_params[:merchant_id])
+    bulk_discount = BulkDiscount.find(bulk_discount_params[:id]).destroy
+
+    redirect_to merchant_bulk_discounts_path(merchant)
   end
 
   private

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -3,7 +3,10 @@
 <h2> All Discounts: </h2>
 <% @bulk_discounts.each do |bulk_discount| %>
   <section id="bulk_discount-<%= bulk_discount.id %>">
-    <li> <%= link_to "#{bulk_discount.name}", merchant_bulk_discount_path(@merchant, bulk_discount) %> :
+
+
+    <li> <%= link_to "DELETE:", merchant_bulk_discount_path(@merchant, bulk_discount), method: :delete %>
+     <%= link_to "#{bulk_discount.name}", merchant_bulk_discount_path(@merchant, bulk_discount) %> :
      <%= bulk_discount.percentage_discount %> Percent Discount,
      Quantity Threshold: <%= bulk_discount.quantity_threshold %>
     </li>

--- a/spec/features/application/home_page_spec.rb
+++ b/spec/features/application/home_page_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'application home page' do
+  it "displays welcome message" do
+    visit "/"
+
+    expect(page).to have_content("Welcome to adopt don't shop!")
+  end
+end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -66,4 +66,33 @@ RSpec.describe 'merchant bulk discounts index' do
 
     expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant_1))
   end
+
+  it "displays delete link next to each bulk discount " do
+    within("#bulk_discount-#{@bulk_discount_1.id}") do
+      expect(page).to have_link("DELETE:")
+    end
+
+    within("#bulk_discount-#{@bulk_discount_2.id}") do
+      expect(page).to have_link("DELETE:")
+    end
+
+    within("#bulk_discount-#{@bulk_discount_3.id}") do
+      expect(page).to have_link("DELETE:")
+    end
+
+    within("#bulk_discount-#{@bulk_discount_4.id}") do
+      expect(page).to have_link("DELETE:")
+    end
+  end
+
+  it "clicks delete link and no longer displays that bulk discount" do
+    expect(page).to have_content(@bulk_discount_1.name)
+
+    within("#bulk_discount-#{@bulk_discount_1.id}") do
+      click_link("DELETE:")
+    end
+
+    expect(page).to_not have_content(@bulk_discount_1.name)
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant_1))
+  end
 end


### PR DESCRIPTION
# Description

Add ability to destroy a bulk discount by clicking a delete link next to the bulk discount's name. This functionality lives within the bulk discounts index.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Feature Tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
